### PR TITLE
Change the default value for lb_routing_path to an empty string

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -5,7 +5,7 @@ server:
   enable_basic_auth: False
   basic_auth:
     iris_twilio_user: 'barbaz'
-  lb_routing_path: '/iris-relay'
+  lb_routing_path: ''
 twilio:
   remote_host: 'localhost:11648'
   auth_token: 'foobar'


### PR DESCRIPTION
This isn't always needed and will break the twilio token computation
if you're running iris-relay bare.